### PR TITLE
Add refresh token feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ go get github.com/abhayptp/go-chatgpt
 
 2. Get bearer token from the browser.
 
+To avoid needing to refresh bearer token every hour, you can also copy "__Secure-next-auth.session-token" key from cookie and pass it in Credentials in Step 3. 
+
+
 <img src="https://user-images.githubusercontent.com/22256898/205469104-d99b6a6a-18d2-4fea-9a58-6936d3be6479.png" width=80%>
 
 
@@ -27,8 +30,11 @@ import (
 
 func main() {
 
-	// Initialize. Copy bearer-token from browser developer tools.
-	c := chatgpt.NewChatGpt(chatgpt.NewClient(chatgpt.NewCredentials("Bearer <Bearer-Token>")))
+	// Initialize. Copy bearer-token and session-token from browser developer tools.
+	c := chatgpt.NewChatGpt(chatgpt.NewClient(&chatgpt.Credentials{
+		BearerToken: "Bearer <bearer-token>",
+		SessionToken: "<session-token>",
+		}))
 
 	// Send message
 	res, err := c.SendMessage("hello")

--- a/auth.go
+++ b/auth.go
@@ -1,11 +1,15 @@
 package chatgpt
 
-type credentials struct {
-	BearerToken string
+import "time"
+
+type Credentials struct {
+	BearerToken     string
+	SessionToken    string
+	tokenExpiryTime time.Time
 }
 
-func NewCredentials(bearerToken string) *credentials {
-	return &credentials{
+func NewCredentials(bearerToken string) *Credentials {
+	return &Credentials{
 		BearerToken: bearerToken,
 	}
 }

--- a/chatgpt_test.go
+++ b/chatgpt_test.go
@@ -8,12 +8,14 @@ import (
 // TestSendMessage tests the send method of the client
 func TestSendMessage(t *testing.T) {
 	// Prepare test data
-	credentials := &credentials{BearerToken: "Bearer <Bearer-Token>"}
-	client := NewChatGpt(NewClient(credentials))
+	chatgpt := NewChatGpt(NewClient(&Credentials{
+		BearerToken:  "Bearer <Bearer-Token>",
+		SessionToken: "<Session-Token>",
+	}))
 	mockRequest := "hello"
 
 	// Run test
-	res, err := client.SendMessage(mockRequest)
+	res, err := chatgpt.SendMessage(mockRequest)
 	if err != nil {
 		t.Errorf("error sending request, %v", err)
 	}

--- a/client.go
+++ b/client.go
@@ -11,15 +11,19 @@ import (
 	"github.com/tmaxmax/go-sse"
 )
 
+const (
+	USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"
+)
+
 type Client interface {
 	Send(*request) (chan *response, error)
 }
 
 type client struct {
-	credentials *credentials
+	credentials *Credentials
 }
 
-func NewClient(credentials *credentials) *client {
+func NewClient(credentials *Credentials) *client {
 	return &client{
 		credentials: credentials,
 	}
@@ -33,7 +37,12 @@ func (c *client) Send(r *request) (res *response, err error) {
 
 	req, err := http.NewRequest("POST", "https://chat.openai.com/backend-api/conversation", bytes.NewReader(reqBytes))
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create request, error: %v", err)
+		return nil, fmt.Errorf("failed to create request, error: %v", err)
+	}
+
+	err = c.refreshAccessTokenIfExpired()
+	if err != nil {
+		return nil, err
 	}
 
 	req.Header.Set("Authority", "chat.openai.com")
@@ -41,7 +50,7 @@ func (c *client) Send(r *request) (res *response, err error) {
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36")
+	req.Header.Set("User-Agent", USER_AGENT)
 
 	var lastItem []byte
 	var validator sse.ResponseValidator = func(r *http.Response) error {
@@ -53,9 +62,10 @@ func (c *client) Send(r *request) (res *response, err error) {
 
 	client := sse.Client{
 		HTTPClient:              http.DefaultClient,
-		DefaultReconnectionTime: 5 * time.Second,
+		DefaultReconnectionTime: 8 * time.Second,
 		ResponseValidator:       validator,
 	}
+
 	conn := client.NewConnection(req)
 	conn.SubscribeMessages(func(event sse.Event) {
 		if event.String() != "[DONE]" {
@@ -78,4 +88,54 @@ func (c *client) Send(r *request) (res *response, err error) {
 		}
 	}
 	return nil, errors.New("result is empty")
+}
+
+func (c *client) refreshAccessTokenIfExpired() error {
+	if !c.credentials.tokenExpiryTime.IsZero() &&
+		c.credentials.tokenExpiryTime.Before(time.Now()) &&
+		c.credentials.BearerToken != "" {
+		return nil
+	}
+
+	req, err := http.NewRequest("GET", "https://chat.openai.com/api/auth/session", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request, error: %v", err)
+	}
+
+	req.Header.Set("User-Agent", USER_AGENT)
+	req.Header.Set("Cookie", fmt.Sprintf("__Secure-next-auth.session-token=%s", c.credentials.SessionToken))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to perform request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result sessionResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	if err != nil {
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if result.Error != "" {
+		if result.Error == "RefreshAccessTokenError" {
+			return errors.New("session token has expired")
+		}
+
+		return errors.New(result.Error)
+	}
+
+	bearerToken := result.AccessToken
+	if bearerToken == "" {
+		return errors.New("unauthorized")
+	}
+
+	expiryTime, err := time.Parse(time.RFC3339, result.Expires)
+	if err != nil {
+		return fmt.Errorf("failed to parse expiry time: %v", err)
+	}
+	c.credentials.BearerToken = "Bearer " + bearerToken
+	c.credentials.tokenExpiryTime = expiryTime
+	return nil
 }

--- a/response.go
+++ b/response.go
@@ -1,5 +1,11 @@
 package chatgpt
 
+type sessionResponse struct {
+	Error       string `json:"error"`
+	Expires     string `json:"expires"`
+	AccessToken string `json:"accessToken"`
+}
+
 type responseMessage struct {
 	ID         string      `json:"id"`
 	Role       string      `json:"role"`


### PR DESCRIPTION
To avoid breaking change of adding extra parameter to `NewCredentials()`, now `Credentials` struct is exposed to the user so they can create it as needed (either pass `SessionToken` or `BearerToken`).



Credits for refresh token feature motivation: https://github.com/m1guelpf/chatgpt-telegram/blob/ae6ca396fa/src/chatgpt/chatgpt.go